### PR TITLE
Support VSL version 1 and 64-bit VXIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	v.Log("", vago.RAW, vago.COPT_TAIL|vago.COPT_BATCH, func(vxid uint32, tag, _type, data string) int {
+	v.Log("", vago.RAW, vago.COPT_TAIL|vago.COPT_BATCH, func(vxid uint64, tag, _type, data string) int {
 		fmt.Printf("%10d %-14s %s %s\n", vxid, tag, _type, data)
 		// -1 : Stop after it finds the first record
 		// >= 0 : Nothing to do but wait

--- a/vago_test.go
+++ b/vago_test.go
@@ -50,7 +50,7 @@ func TestLog(t *testing.T) {
 		t.Fatal("Expected nil")
 	}
 	defer v.Close()
-	err = v.Log("", RAW, COPT_TAIL|COPT_BATCH, func(vxid uint32, tag, _type, data string) int {
+	err = v.Log("", RAW, COPT_TAIL|COPT_BATCH, func(vxid uint64, tag, _type, data string) int {
 		if vxid == 0 && tag == "CLI" && _type == "-" && strings.Contains(data, "PONG") {
 			return -1
 		}
@@ -73,7 +73,7 @@ func TestLogGoroutineClose(t *testing.T) {
 	wg.Add(1)
 	go func(v *Varnish) {
 		defer wg.Done()
-		err = v.Log("", RAW, COPT_TAIL|COPT_BATCH, func(vxid uint32, tag, _type, data string) int {
+		err = v.Log("", RAW, COPT_TAIL|COPT_BATCH, func(vxid uint64, tag, _type, data string) int {
 			return -1
 		})
 	}(v)
@@ -93,7 +93,7 @@ func TestInvalidQuery(t *testing.T) {
 		t.Fatal("Expected nil")
 	}
 	defer v.Close()
-	err = v.Log("nonexistent", RAW, COPT_TAIL|COPT_BATCH, func(vxid uint32, tag, _type, data string) int {
+	err = v.Log("nonexistent", RAW, COPT_TAIL|COPT_BATCH, func(vxid uint64, tag, _type, data string) int {
 		return -1
 	})
 	if _, ok := err.(ErrVSL); !ok {


### PR DESCRIPTION
The VSL format was changed, with 3 header lines instead of 2. Namely, VXIDs are now 64-bit integers.

This breaks the library interface (because we change the callback type).

Using the version field, we can still support reading the previous version of the VSL records.

See: https://github.com/varnishcache/varnish-cache/blob/varnish-7.2.1/include/vapi/vsl_int.h
See: https://github.com/varnishcache/varnish-cache/blob/varnish-7.3.0/include/vapi/vsl_int.h
Fixes: https://github.com/varnishcache-friends/vago/issues/20